### PR TITLE
chore: update to atlantis 0.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.source=https://github.com/clicampo/docker-atlanti
 
 ENV TERRAGRUNT_VERSION=v0.36.0 \
     VAULT_VERSION=1.9.2 \
-    TERRAGRUNT_ATLANTIS_CONFIG_VERSION=1.11.0 \
+    TERRAGRUNT_ATLANTIS_CONFIG_VERSION=1.12.3 \
     TERRAFORM_VERSION=1.1.2 \
     DEFAULT_TERRAFORM_VERSION=1.1.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM runatlantis/atlantis:v0.18.2
 
 LABEL org.opencontainers.image.source=https://github.com/clicampo/docker-atlantis-terragrunt
 
-ENV TERRAGRUNT_VERSION=v0.35.16 \
+ENV TERRAGRUNT_VERSION=v0.36.0 \
     VAULT_VERSION=1.9.2 \
     TERRAGRUNT_ATLANTIS_CONFIG_VERSION=1.11.0 \
     TERRAFORM_VERSION=1.1.2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ LABEL org.opencontainers.image.source=https://github.com/clicampo/docker-atlanti
 ENV TERRAGRUNT_VERSION=v0.36.0 \
     VAULT_VERSION=1.9.2 \
     TERRAGRUNT_ATLANTIS_CONFIG_VERSION=1.12.3 \
-    TERRAFORM_VERSION=1.1.2 \
-    DEFAULT_TERRAFORM_VERSION=1.1.2
+    TERRAFORM_VERSION=1.1.4 \
+    DEFAULT_TERRAFORM_VERSION=1.1.4
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM runatlantis/atlantis:v0.18.1
+FROM runatlantis/atlantis:v0.18.2
 
 LABEL org.opencontainers.image.source=https://github.com/clicampo/docker-atlantis-terragrunt
 


### PR DESCRIPTION
This fixes a bug with Basic Auth that was leaving the Atlantis open to everyone.

https://github.com/runatlantis/atlantis/pull/2008
